### PR TITLE
Add support for naive introspection of wrapped unsync functions.

### DIFF
--- a/test/test_unsync.py
+++ b/test/test_unsync.py
@@ -1,6 +1,6 @@
+from functools import wraps
 from unittest import TestCase
 
-import time
 from pytest import raises
 from unsync import unsync
 import asyncio
@@ -81,3 +81,19 @@ class DecoratorTests(TestCase):
             return 'faff'
 
         self.assertEqual('faff', cpu_bound().result())
+
+    def test_nested_decorator_retains_wrapped_function_attributes(self):
+        def on(attr_value):
+            @wraps(attr_value)
+            def wrapper(f):
+                f.attr_name = attr_value
+                return f
+
+            return wrapper
+
+        @on("faff")
+        @unsync
+        def some_func(): pass
+
+        assert some_func.attr_name == "faff"
+        assert some_func.__name__ == "some_func"

--- a/unsync/unsync.py
+++ b/unsync/unsync.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent
+import functools
 import inspect
 import threading
 import os
@@ -35,6 +36,7 @@ class unsync(object):
     def _set_func(self, func):
         assert inspect.isfunction(func)
         self.func = func
+        functools.update_wrapper(self, func)
         unsync.unsync_functions[(func.__module__, func.__name__)] = func
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
Uses the standard `functools` to preserve the attributes of functions wrapped by `@unsync`.

Fixes #4.