### PR TITLE
Add support for preserving attributes of nested instance methods

### DIFF
--- a/test/test_unsync.py
+++ b/test/test_unsync.py
@@ -95,8 +95,7 @@ def set_attr(attr_value):
 
 
 class NestedDecoratorTests(TestCase):
-    @classmethod
-    def test_nested_decorator_retains_wrapped_function_attributes(cls):
+    def test_nested_decorator_retains_wrapped_function_attributes(self):
 
         @unsync
         @set_attr("faff")
@@ -105,8 +104,7 @@ class NestedDecoratorTests(TestCase):
         assert wrapped_func.__name__ == "wrapped_func"
         assert wrapped_func.attr == "faff"
 
-    @classmethod
-    def test_nested_decorator_retains_wrapped_class_method_attributes(cls):
+    def test_nested_decorator_retains_wrapped_class_method_attributes(self):
 
         class Class:
 

--- a/unsync/unsync.py
+++ b/unsync/unsync.py
@@ -56,7 +56,12 @@ class unsync(object):
         return Unfuture(future)
 
     def __get__(self, instance, owner):
-        return lambda *args, **kwargs: self(instance, *args, **kwargs)
+        def _call(*args, **kwargs):
+            return self(instance, *args, **kwargs)
+
+        functools.update_wrapper(_call, self.func)
+        return _call
+
 
 def _multiprocess_target(func_name, *args, **kwargs):
     # On Windows MP turns the main module into __mp_main__ in multiprocess targets
@@ -121,6 +126,7 @@ class Unfuture:
         if hasattr(result, '__await__'):
             return await result
         return result
+
 
 unsync.thread = Thread(target=unsync.thread_target, args=(unsync.loop,), daemon=True)
 unsync.thread.start()


### PR DESCRIPTION
This PR expands on #5, which used [functools.update_wrapper](https://docs.python.org/3/library/functools.html?highlight=update_wrapper#functools.update_wrapper) to ensure that the ``@unsync`` decorator is well-behaved, and preserves some key attributes of wrapped functions (most notable the function name).

It turns out however that unsync handles wrapping class methods slightly differently to wrapping regular functions, which meant that for two identically named callables `wrapped_func`:

```python
class Class:

    @unsync
    async def wrapped_func(self): pass

@unsync
async def wrapped_func(): pass
```

...the `__name__` attribute of the class method would not be preserved, such that `wrapped_func.__name__ != Class().wrapped_func.__name__`

This PR ports the behaviour from #5 to class methods so that attributes of both types of callables are preserved in a similar fashion.

More details included in the expanded test cases.