### PR TITLE
Adding CI using github actions (issue 11), Updated docs (issue 10 and typing guidelines)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,34 @@
+name: Python package
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest

--- a/README.md
+++ b/README.md
@@ -25,10 +25,8 @@ async def sync_async():
     await asyncio.sleep(0.1)
     return 'I hate event loops'
 
-annoying_event_loop = asyncio.get_event_loop()
-future = asyncio.ensure_future(sync_async(), loop=annoying_event_loop)
-annoying_event_loop.run_until_complete(future)
-print(future.result())
+result = asyncio.run(sync_async())
+print(result)
 ```
 
 Same example with `unsync`:

--- a/README.md
+++ b/README.md
@@ -120,3 +120,27 @@ Which prints:
 
     {0: 2, 1: 4, 2: 6, 3: 8, 4: 10, 5: 12, 6: 14, 7: 16, 8: 18, 9: 20}
     Executed in 0.22115683555603027 seconds
+    
+## Preserving typing
+As far as we know it is not possible to change the return type of a method or function using a decorator.
+Therefore, we need a workaround to properly use IntelliSense. You have three options in general:
+
+1. Ignore type warnings.
+2. Use a suppression statement where you reach the type warning.
+
+    A. When defining the unsynced method by changing the return type to an `Unfuture`.
+    
+    B. When using the unsynced method.
+    
+3. Wrap the function without a decorator. Example:
+    ```python 
+    def function_name(x: str) -> Unfuture[str]:
+        async_method = unsync(__function_name_synced)
+        return async_method(x)
+
+    def __function_name_synced(x: str) -> str:
+        return x + 'a'
+
+    future_result = function_name('b')
+    self.assertEqual('ba', future_result.result())
+   ```

--- a/examples/continuation.py
+++ b/examples/continuation.py
@@ -3,6 +3,7 @@ import time
 
 from unsync import unsync
 
+
 # Using Unfuture.then chains asynchronous calls and returns an Unfuture that wraps both the source, and continuation
 
 @unsync
@@ -10,10 +11,12 @@ async def initiate(request):
     await asyncio.sleep(0.1)
     return request + 1
 
+
 @unsync
 async def process(task):
     await asyncio.sleep(0.1)
     return task.result() * 2
+
 
 start = time.time()
 print(initiate(3).then(process).result())

--- a/examples/exceptions.py
+++ b/examples/exceptions.py
@@ -2,12 +2,14 @@ import asyncio
 
 from unsync import unsync
 
+
 # Exceptions are thrown when results are observed
 
 @unsync
 async def throws_exception():
     await asyncio.sleep(0.1)
     raise NotImplementedError
+
 
 # No exception is thrown here
 task = throws_exception()
@@ -17,6 +19,7 @@ try:
     task.result()
 except NotImplementedError:
     print("Delayed result() exception!")
+
 
 # The same applies to async functions awaiting methods
 @unsync
@@ -28,5 +31,6 @@ async def calls_throws_exception():
         await task
     except NotImplementedError:
         print("Delayed awaited exception!")
+
 
 calls_throws_exception().result()

--- a/examples/mixing_methods.py
+++ b/examples/mixing_methods.py
@@ -3,6 +3,7 @@ import asyncio
 
 from unsync import unsync
 
+
 # All Unfutures are compatible regardless of how they were started
 
 @unsync
@@ -11,6 +12,7 @@ def non_async_function(num):
        This gets executed in the ThreadPoolExecutor unsync.executor"""
     time.sleep(0.1)
     return num, num + 1
+
 
 @unsync
 async def result_continuation(task):
@@ -21,6 +23,7 @@ async def result_continuation(task):
     num, res = task.result()
     return num, res * 2
 
+
 @unsync
 async def result_processor(tasks):
     """An async result aggregator that combines all the results
@@ -30,6 +33,7 @@ async def result_processor(tasks):
         num, res = await task
         output[num] = res
     return output
+
 
 start = time.time()
 print(result_processor([non_async_function(i).then(result_continuation) for i in range(10)]).result())

--- a/examples/sleep.py
+++ b/examples/sleep.py
@@ -2,16 +2,19 @@ import asyncio
 
 from unsync import unsync
 
+
 # Synchronous style
 
 async def sync_async():
     await asyncio.sleep(0.1)
     return 'I hate event loops'
 
+
 annoying_event_loop = asyncio.get_event_loop()
 future = asyncio.ensure_future(sync_async(), loop=annoying_event_loop)
 annoying_event_loop.run_until_complete(future)
 print(future.result())
+
 
 # Unsynchronous style
 
@@ -19,5 +22,6 @@ print(future.result())
 async def unsync_async():
     await asyncio.sleep(0.1)
     return 'I like decorators'
+
 
 print(unsync_async().result())

--- a/examples/thread_executor.py
+++ b/examples/thread_executor.py
@@ -2,12 +2,14 @@ import time
 
 from unsync import unsync
 
+
 # Convert synchronous functions into Unfutures to be executed in `unsync.executor`
 
 @unsync
 def non_async_function(seconds):
     time.sleep(seconds)
     return 'Run in parallel!'
+
 
 start = time.time()
 tasks = [non_async_function(0.1) for _ in range(10)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# This is a placeholder file. We currently have no dependencies

--- a/test/test_call_ordering.py
+++ b/test/test_call_ordering.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 import asyncio
 
-from unsync import *
+from unsync import unsync
 
 
 class CallOrderingTests(TestCase):

--- a/test/test_future.py
+++ b/test/test_future.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import asyncio
 import time
 
-from unsync import *
+from unsync import unsync, Unfuture
 
 
 class FutureTests(TestCase):

--- a/test/test_process_executor.py
+++ b/test/test_process_executor.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 import time
 
-from unsync import *
+from unsync import unsync
 
 
 @unsync(cpu_bound=True)
@@ -12,13 +12,16 @@ def cpu_bound(duration):
         faff += 1
     return 'faff'
 
+
 class ProcessTests(TestCase):
     def test_raw_cpu_bound(self):
         cpu_bound(0.01).result()
+
     def test_cpu_bound(self):
         @unsync
         async def aggregator(tasks):
             return [await task for task in tasks]
+
         start = time.time()
         tasks = [cpu_bound(0.01) for _ in range(100)]
         self.assertTrue(all([result == 'faff' for result in aggregator(tasks).result()]))

--- a/test/test_thread_executor.py
+++ b/test/test_thread_executor.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 import asyncio
 import time
 
-from unsync import *
+from unsync import unsync
 
 
 class ThreadedTests(TestCase):

--- a/test/test_unsync.py
+++ b/test/test_unsync.py
@@ -81,11 +81,26 @@ class DecoratorTests(TestCase):
 
         self.assertEqual('faff', cpu_bound().result())
 
+    def test_implementation_without_decorator(self):
+        """
+        This implementation is useful to preserve type hints without an ignore statement.
+        """
+        def function_name(x: str) -> Unfuture[str]:
+            async_method = unsync(__function_name_synced)
+            return async_method(x)
+
+        def __function_name_synced(x: str) -> str:
+            return x + 'a'
+
+        future_result = function_name('b')
+        self.assertEqual('ba', future_result.result())
+
 
 def set_attr(attr_value):
     """
     Sample decorator for testing nested unsync decorators.
     """
+
     @wraps(attr_value)
     def wrapper(f):
         f.attr = attr_value
@@ -96,7 +111,6 @@ def set_attr(attr_value):
 
 class NestedDecoratorTests(TestCase):
     def test_nested_decorator_retains_wrapped_function_attributes(self):
-
         @unsync
         @set_attr("faff")
         async def wrapped_func(): pass
@@ -105,7 +119,6 @@ class NestedDecoratorTests(TestCase):
         assert wrapped_func.attr == "faff"
 
     def test_nested_decorator_retains_wrapped_class_method_attributes(self):
-
         class Class:
 
             @unsync

--- a/unsync/__init__.py
+++ b/unsync/__init__.py
@@ -1,1 +1,3 @@
 from unsync.unsync import unsync, Unfuture
+
+__all__ = ["unsync", "Unfuture"]

--- a/unsync/unsync.py
+++ b/unsync/unsync.py
@@ -65,8 +65,10 @@ class unsync(object):
         functools.update_wrapper(_call, self.func)
         return _call
 
+
 def _isfunction(obj):
     return inspect.isfunction(obj) or inspect._signature_is_functionlike(obj)
+
 
 def _multiprocess_target(func_name, *args, **kwargs):
     # On Windows MP turns the main module into __mp_main__ in multiprocess targets
@@ -77,6 +79,7 @@ def _multiprocess_target(func_name, *args, **kwargs):
 
 
 T = TypeVar('T')
+
 
 class Unfuture(Generic[T]):
     @staticmethod


### PR DESCRIPTION
* Added CI through using github actions (hopefully works from the moment the pull-request is accepted)
* While adding CI I had to edit some other files to align them with flake8.
* Added a placeholder requirments.txt to minimize the changes to the standard github CI script for python packages.
* Updated the docs in accordance with the suggestion from issue 10 (that indeed is the new preferred method to running asyncio according to the python docs.
* Expanded upon the readme by giving suggestions for using typing while using asyncio. 