### PR TITLE
Added support for uvloop in case of Mac / Linux systems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
 from setuptools import setup
 from pathlib import Path
+import os
+
+required = None
+if os.name == "posix":
+    required = ["uvloop"]
 
 setup(
     name='unsync',
@@ -10,6 +15,7 @@ setup(
     author='Alex-Sherman',
     author_email='asherman1024@gmail.com',
     description='Unsynchronize asyncio',
+    install_requires = required,
     long_description=(Path(__file__).parent / "README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
 )

--- a/unsync/unsync.py
+++ b/unsync/unsync.py
@@ -7,11 +7,18 @@ import os
 from threading import Thread
 from typing import Generic, TypeVar
 
+if os.name == "posix":
+    import uvloop
 
 class unsync(object):
     thread_executor = concurrent.futures.ThreadPoolExecutor()
     process_executor = None
-    loop = asyncio.new_event_loop()
+    
+    if os.name == "posix":
+        loop = uvloop.new_event_loop()
+    else:
+        loop = asyncio.new_event_loop()
+        
     thread = None
     unsync_functions = {}
 


### PR DESCRIPTION
I have been using unsync for some time. 

I thought that it would be nice if unsync could support uvloop for async methods for atleast mac and linux systems at least since windows is not supported yet by uvloop.

Submitting a PR for the same. Let me know if this looks good enough.
