### PR TITLE
Support setting custom event loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,20 @@ Therefore, we need a workaround to properly use IntelliSense. You have three opt
     future_result = function_name('b')
     self.assertEqual('ba', future_result.result())
    ```
+
+## Custom Event Loops
+In order to use custom event loops, be sure to set the event loop policy before calling any `@unsync` methods.
+For example, to use `uvloop` simply:
+
+```python
+import unsync
+import uvloop
+
+@unsync
+async def main():
+    # Main entry-point.
+    ...
+
+uvloop.install() # Equivalent to asyncio.set_event_loop_policy(EventLoopPolicy())
+main()
+```

--- a/test/test_custom_event_loop.py
+++ b/test/test_custom_event_loop.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+import asyncio
+
+from unsync import unsync
+
+
+class TestEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+    def new_event_loop(self):
+        loop = super().new_event_loop()
+        loop.derp = "faff"
+        return loop
+
+asyncio.set_event_loop_policy(TestEventLoopPolicy())
+
+
+class CustomEventTest(TestCase):
+    def test_custom_event_loop(self):
+        @unsync
+        async def method():
+            return True
+
+        self.assertTrue(method().result())
+        self.assertEqual(unsync.loop.derp, "faff")


### PR DESCRIPTION
Based off the request in #31 this PR support setting custom event loop policies _after_ import but _before_ calling an `@unsync` method.

I think further work could be done to support changing event loops during execution, but it seems too complicated and not sure if anyone would benefit from that.