### PR TITLE
modification of async example in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ async def main():
     print(future1.result() + future2.result())
 
 asyncio.run(main())
+# Takes 1 second to run
 ```
 
 Same example with `unsync`:

--- a/README.md
+++ b/README.md
@@ -25,10 +25,16 @@ async def sync_async():
     await asyncio.sleep(1)
     return 'I hate event loops'
 
-result1 = asyncio.run(sync_async())
-result2 = asyncio.run(sync_async())
-print(result1 + result2)
-# Takes 2 seconds to run
+
+async def main():
+    future1 = asyncio.create_task(sync_async())
+    future2 = asyncio.create_task(sync_async())
+
+    await future1, future2
+
+    print(future1.result() + future2.result())
+
+asyncio.run(main())
 ```
 
 Same example with `unsync`:


### PR DESCRIPTION
The async io example within the documentation did not use the event-loop, as asyncio.run does execute the async method. This PR changes the usage of asyncio to work properly. It points also out, that unsync has a much shorter syctax. 