### PR TITLE
Refactors

### DIFF
--- a/test/test_custom_event_loop.py
+++ b/test/test_custom_event_loop.py
@@ -4,13 +4,13 @@ import asyncio
 from unsync import unsync
 
 
-class TestEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+class _TestEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
     def new_event_loop(self):
         loop = super().new_event_loop()
         loop.derp = "faff"
         return loop
 
-asyncio.set_event_loop_policy(TestEventLoopPolicy())
+asyncio.set_event_loop_policy(_TestEventLoopPolicy())
 
 
 class CustomEventTest(TestCase):

--- a/test/test_custom_event_loop.py
+++ b/test/test_custom_event_loop.py
@@ -4,13 +4,13 @@ import asyncio
 from unsync import unsync
 
 
-class _TestEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+class EventLoopTestPolicy(asyncio.DefaultEventLoopPolicy):
     def new_event_loop(self):
         loop = super().new_event_loop()
         loop.derp = "faff"
         return loop
 
-asyncio.set_event_loop_policy(_TestEventLoopPolicy())
+asyncio.set_event_loop_policy(EventLoopTestPolicy())
 
 
 class CustomEventTest(TestCase):

--- a/unsync/unsync.py
+++ b/unsync/unsync.py
@@ -16,19 +16,19 @@ class unsync_meta(type):
 
     @property
     def loop(cls):
-        if not hasattr(cls, '_loop'):
+        if getattr(cls, '_loop', None) is None:
             unsync_meta._init_loop(cls)
         return cls._loop
 
     @property
     def thread(cls):
-        if not hasattr(cls, '_thread'):
+        if getattr(cls, '_thread', None) is None:
             unsync_meta._init_loop(cls)
         return cls._thread
 
     @property
     def process_executor(cls):
-        if not hasattr(cls, '_process_executor'):
+        if getattr(cls, '_process_executor', None) is None:
             cls._process_executor = concurrent.futures.ProcessPoolExecutor()
         return cls._process_executor
 

--- a/unsync/unsync.py
+++ b/unsync/unsync.py
@@ -16,19 +16,19 @@ class unsync_meta(type):
 
     @property
     def loop(cls):
-        if getattr(cls, '_loop', None) is None:
+        if not hasattr(cls, '_loop'):
             unsync_meta._init_loop(cls)
         return cls._loop
 
     @property
     def thread(cls):
-        if getattr(cls, '_thread', None) is None:
+        if not hasattr(cls, '_thread'):
             unsync_meta._init_loop(cls)
         return cls._thread
 
     @property
     def process_executor(cls):
-        if getattr(cls, '_process_executor', None) is None:
+        if not hasattr(cls, '_process_executor'):
             cls._process_executor = concurrent.futures.ProcessPoolExecutor()
         return cls._process_executor
 


### PR DESCRIPTION
- use `hasattr` instead of `getattr(..., None) is None`
- Rename `TestEventLoopPolicy` class so that pytest doesn't warn about not being able to test that class.