### PR TITLE
Added Python 3.9 and 3.10 to the CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
* Ran the tests locally in Python 3.9 and Python 3.10. All of them passed. 
* Tested the public API manually on both of the versions. 
* Updated the CI to include the new versions (Made all the version numbers strings, otherwise, YAML syntax would break the 3.10 literal). 
* Removed Python 3.6 as it has reached its [EOL](https://endoflife.date/python) on December 23, 2021. 